### PR TITLE
Fixed \bibentry error

### DIFF
--- a/presenations/general/general.tex
+++ b/presenations/general/general.tex
@@ -170,7 +170,8 @@
     
 
 \begin{document}
-
+\nobibliography* %Allows you to put \bibentry citations in the footers of frames/slides.
+%This does NOT effect your ability to put a bibliography slide at the end
 
 %%%%% title page with no footer
 {


### PR DESCRIPTION
Added \nobibliography* immediately after \begin{document}

Without this command, citations do not correctly print in the footers. You are still able to have a bibliography slide with this command in place.

The only edits are made on the two lines below \begin{document} (lines 172-174) in master>presentations>general>general.tex